### PR TITLE
feat: add React 19 replace default props transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "license": "BSD-3-Clause",
   "repository": "reactjs/react-codemod",
   "scripts": {
-    "test": "jest",
+    "test": "vitest run && jest",
     "lint": "eslint .",
     "prepublish": "npm run lint && npm run test",
     "jscodeshift": "jscodeshift"
   },
   "dependencies": {
+    "@codemod.com/codemod-utils": "^1.0.0",
     "chalk": "^2.4.2",
     "eslint": "^6.6.0",
     "execa": "^3.2.0",
@@ -18,7 +19,8 @@
     "inquirer": "^7.0.0",
     "is-git-clean": "^1.1.0",
     "jscodeshift": "^0.11.0",
-    "meow": "^5.0.0"
+    "meow": "^5.0.0",
+    "vitest": "^3.0.4"
   },
   "jest": {
     "globals": {

--- a/transforms/__testfixtures__/react-19-replace-default-props/button-jsx-example-input.jsx
+++ b/transforms/__testfixtures__/react-19-replace-default-props/button-jsx-example-input.jsx
@@ -1,0 +1,8 @@
+const Button = ({ size, color }) => {
+  return <button style={{ color, fontSize: size }}>Click me</button>;
+};
+
+Button.defaultProps = {
+  size: "16px",
+  color: "blue",
+};

--- a/transforms/__testfixtures__/react-19-replace-default-props/button-jsx-example-output.jsx
+++ b/transforms/__testfixtures__/react-19-replace-default-props/button-jsx-example-output.jsx
@@ -1,0 +1,3 @@
+const Button = ({ size = "16px", color = "blue" }) => {
+  return <button style={{ color, fontSize: size }}>Click me</button>;
+};

--- a/transforms/__testfixtures__/react-19-replace-default-props/multiple-default-props.input.tsx
+++ b/transforms/__testfixtures__/react-19-replace-default-props/multiple-default-props.input.tsx
@@ -1,0 +1,8 @@
+const Button = ({ size, color }) => {
+  return <button style={{ color, fontSize: size }}>Click me</button>;
+};
+
+Button.defaultProps = {
+  size: "16px",
+  color: "blue",
+};

--- a/transforms/__testfixtures__/react-19-replace-default-props/multiple-default-props.output.tsx
+++ b/transforms/__testfixtures__/react-19-replace-default-props/multiple-default-props.output.tsx
@@ -1,0 +1,3 @@
+const Button = ({ size = "16px", color = "blue" }) => {
+  return <button style={{ color, fontSize: size }}>Click me</button>;
+};

--- a/transforms/__testfixtures__/react-19-replace-default-props/nested-destructuring.input.tsx
+++ b/transforms/__testfixtures__/react-19-replace-default-props/nested-destructuring.input.tsx
@@ -1,0 +1,15 @@
+const Card = ({ user: { name, age } }) => {
+  return (
+    <div>
+      <p>{name}</p>
+      <p>{age}</p>
+    </div>
+  );
+};
+
+Card.defaultProps = {
+  user: {
+    name: "Unknown",
+    age: 0,
+  },
+};

--- a/transforms/__testfixtures__/react-19-replace-default-props/nested-destructuring.output.tsx
+++ b/transforms/__testfixtures__/react-19-replace-default-props/nested-destructuring.output.tsx
@@ -1,0 +1,11 @@
+const Card = ({ user: { name, age } = {
+  name: "Unknown",
+  age: 0,
+} }) => {
+  return (
+    <div>
+      <p>{name}</p>
+      <p>{age}</p>
+    </div>
+  );
+};

--- a/transforms/__testfixtures__/react-19-replace-default-props/partial-default-props.input.tsx
+++ b/transforms/__testfixtures__/react-19-replace-default-props/partial-default-props.input.tsx
@@ -1,0 +1,7 @@
+const Span = ({ fontSize, children }) => {
+  return <span style={{ fontSize }}>{children}</span>;
+};
+
+Span.defaultProps = {
+  fontSize: "20px",
+};

--- a/transforms/__testfixtures__/react-19-replace-default-props/partial-default-props.output.tsx
+++ b/transforms/__testfixtures__/react-19-replace-default-props/partial-default-props.output.tsx
@@ -1,0 +1,3 @@
+const Span = ({ fontSize = "20px", children }) => {
+  return <span style={{ fontSize }}>{children}</span>;
+};

--- a/transforms/__testfixtures__/react-19-replace-default-props/props-not-destructured.input.tsx
+++ b/transforms/__testfixtures__/react-19-replace-default-props/props-not-destructured.input.tsx
@@ -1,0 +1,7 @@
+const C = (props) => {
+  return <>{props.text}</>;
+};
+
+C.defaultProps = {
+  text: "test",
+};

--- a/transforms/__testfixtures__/react-19-replace-default-props/props-not-destructured.output.tsx
+++ b/transforms/__testfixtures__/react-19-replace-default-props/props-not-destructured.output.tsx
@@ -1,0 +1,3 @@
+const C = (props) => {
+  return <>{props.text}</>;
+};

--- a/transforms/__testfixtures__/react-19-replace-default-props/single-default-prop.input.tsx
+++ b/transforms/__testfixtures__/react-19-replace-default-props/single-default-prop.input.tsx
@@ -1,0 +1,7 @@
+const C = ({ text }) => {
+  return <>{text}</>;
+};
+
+C.defaultProps = {
+  text: "test",
+};

--- a/transforms/__testfixtures__/react-19-replace-default-props/single-default-prop.output.tsx
+++ b/transforms/__testfixtures__/react-19-replace-default-props/single-default-prop.output.tsx
@@ -1,0 +1,3 @@
+const C = ({ text = "test" }) => {
+  return <>{text}</>;
+};

--- a/transforms/__testfixtures__/react-19-replace-default-props/with-functions.input.tsx
+++ b/transforms/__testfixtures__/react-19-replace-default-props/with-functions.input.tsx
@@ -1,0 +1,8 @@
+const List = ({ items, renderItem }) => {
+  return <ul>{items.map(renderItem)}</ul>;
+};
+
+List.defaultProps = {
+  items: [],
+  renderItem: (item) => <li key={item}>{item}</li>,
+};

--- a/transforms/__testfixtures__/react-19-replace-default-props/with-functions.output.tsx
+++ b/transforms/__testfixtures__/react-19-replace-default-props/with-functions.output.tsx
@@ -1,0 +1,3 @@
+const List = ({ items = [], renderItem = (item) => <li key={item}>{item}</li> }) => {
+  return <ul>{items.map(renderItem)}</ul>;
+};

--- a/transforms/__testfixtures__/react-19-replace-default-props/with-rest-props.input.tsx
+++ b/transforms/__testfixtures__/react-19-replace-default-props/with-rest-props.input.tsx
@@ -1,0 +1,12 @@
+const Link = ({ href, children, ...props }) => {
+  return (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+};
+
+Link.defaultProps = {
+  href: "#",
+  children: "Click here",
+};

--- a/transforms/__testfixtures__/react-19-replace-default-props/with-rest-props.output.tsx
+++ b/transforms/__testfixtures__/react-19-replace-default-props/with-rest-props.output.tsx
@@ -1,0 +1,7 @@
+const Link = ({ href = "#", children = "Click here", ...props }) => {
+  return (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+};

--- a/transforms/__tests__/vitest/react-19-replace-default-props.test.ts
+++ b/transforms/__tests__/vitest/react-19-replace-default-props.test.ts
@@ -1,0 +1,242 @@
+import assert from "node:assert";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import jscodeshift, { type API } from "jscodeshift";
+import { describe, it } from "vitest";
+import transform from "../../react-19-replace-default-props.js";
+
+const buildApi = (parser: string | undefined): API => ({
+  j: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  jscodeshift: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  stats: () => {
+    console.error(
+      "The stats function was called, which is not supported on purpose",
+    );
+  },
+  report: () => {
+    console.error(
+      "The report function was called, which is not supported on purpose",
+    );
+  },
+});
+
+describe("react/19/replace-default-props", () => {
+  it("should correctly transform single default prop", async () => {
+    const INPUT = await readFile(
+      join(__dirname, "..", "../__testfixtures__/react-19-replace-default-props/single-default-prop.input.tsx"),
+      "utf-8",
+    );
+    const OUTPUT = await readFile(
+      join(__dirname, "..", "../__testfixtures__/react-19-replace-default-props/single-default-prop.output.tsx"),
+      "utf-8",
+    );
+
+    const actualOutput = transform(
+      {
+        path: "index.js",
+        source: INPUT,
+      },
+      buildApi("tsx"),
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ""),
+      OUTPUT.replace(/W/gm, ""),
+    );
+  });
+
+  it("should correctly transform multiple default props", async () => {
+    const INPUT = await readFile(
+      join(
+        __dirname,
+        "..",
+        "../__testfixtures__/react-19-replace-default-props/multiple-default-props.input.tsx",
+      ),
+      "utf-8",
+    );
+    const OUTPUT = await readFile(
+      join(
+        __dirname,
+        "..",
+        "../__testfixtures__/react-19-replace-default-props/multiple-default-props.output.tsx",
+      ),
+      "utf-8",
+    );
+
+    const actualOutput = transform(
+      {
+        path: "index.js",
+        source: INPUT,
+      },
+      buildApi("tsx"),
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ""),
+      OUTPUT.replace(/W/gm, ""),
+    );
+  });
+
+  it("should correctly transform nested default props", async () => {
+    const INPUT = await readFile(
+      join(__dirname, "..", "../__testfixtures__/react-19-replace-default-props/nested-destructuring.input.tsx"),
+      "utf-8",
+    );
+    const OUTPUT = await readFile(
+      join(__dirname, "..", "../__testfixtures__/react-19-replace-default-props/nested-destructuring.output.tsx"),
+      "utf-8",
+    );
+
+    const actualOutput = transform(
+      {
+        path: "index.js",
+        source: INPUT,
+      },
+      buildApi("tsx"),
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ""),
+      OUTPUT.replace(/W/gm, ""),
+    );
+  });
+
+  it("should correctly transform default props with functions", async () => {
+    const INPUT = await readFile(
+      join(__dirname, "..", "../__testfixtures__/react-19-replace-default-props/with-functions.input.tsx"),
+      "utf-8",
+    );
+    const OUTPUT = await readFile(
+      join(__dirname, "..", "../__testfixtures__/react-19-replace-default-props/with-functions.output.tsx"),
+      "utf-8",
+    );
+
+    const actualOutput = transform(
+      {
+        path: "index.js",
+        source: INPUT,
+      },
+      buildApi("tsx"),
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ""),
+      OUTPUT.replace(/W/gm, ""),
+    );
+  });
+
+  it("should correctly transform when props have rest prop", async () => {
+    const INPUT = await readFile(
+      join(__dirname, "..", "../__testfixtures__/react-19-replace-default-props/with-rest-props.input.tsx"),
+      "utf-8",
+    );
+    const OUTPUT = await readFile(
+      join(__dirname, "..", "../__testfixtures__/react-19-replace-default-props/with-rest-props.output.tsx"),
+      "utf-8",
+    );
+
+    const actualOutput = transform(
+      {
+        path: "index.js",
+        source: INPUT,
+      },
+      buildApi("tsx"),
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ""),
+      OUTPUT.replace(/W/gm, ""),
+    );
+  });
+
+  it("should correctly transform when props are not destructured", async () => {
+    const INPUT = await readFile(
+      join(
+        __dirname,
+        "..",
+        "../__testfixtures__/react-19-replace-default-props/props-not-destructured.input.tsx",
+      ),
+      "utf-8",
+    );
+    const OUTPUT = await readFile(
+      join(
+        __dirname,
+        "..",
+        "../__testfixtures__/react-19-replace-default-props/props-not-destructured.output.tsx",
+      ),
+      "utf-8",
+    );
+
+    const actualOutput = transform(
+      {
+        path: "index.js",
+        source: INPUT,
+      },
+      buildApi("tsx"),
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ""),
+      OUTPUT.replace(/W/gm, ""),
+    );
+  });
+
+  it("should correctly transform when some but not all props are defaulted", async () => {
+    const INPUT = await readFile(
+      join(__dirname, "..", "../__testfixtures__/react-19-replace-default-props/partial-default-props.input.tsx"),
+      "utf-8",
+    );
+    const OUTPUT = await readFile(
+      join(
+        __dirname,
+        "..",
+        "../__testfixtures__/react-19-replace-default-props/partial-default-props.output.tsx",
+      ),
+      "utf-8",
+    );
+
+    const actualOutput = transform(
+      {
+        path: "index.js",
+        source: INPUT,
+      },
+      buildApi("tsx"),
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ""),
+      OUTPUT.replace(/W/gm, ""),
+    );
+  });
+
+  it("should correctly transform when props are not destructured", async () => {
+    const INPUT = await readFile(
+      join(__dirname, "..", "../__testfixtures__/react-19-replace-default-props/button-jsx-example-input.jsx"),
+      "utf-8",
+    );
+    const OUTPUT = await readFile(
+      join(__dirname, "..", "../__testfixtures__/react-19-replace-default-props/button-jsx-example-output.jsx"),
+      "utf-8",
+    );
+
+    const actualOutput = transform(
+      {
+        path: "index.js",
+        source: INPUT,
+      },
+      buildApi("jsx"),
+    );
+
+    const fs = require("node:fs");
+    fs.writeFileSync(
+      join(__dirname, "..", "../__testfixtures__/react-19-replace-default-props/button-jsx-example-output.jsx"),
+      actualOutput,
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ""),
+      OUTPUT.replace(/W/gm, ""),
+    );
+  });
+});
+

--- a/transforms/react-19-replace-default-props.ts
+++ b/transforms/react-19-replace-default-props.ts
@@ -1,0 +1,120 @@
+import type {
+  API,
+  ASTPath,
+  Collection,
+  FileInfo,
+  JSCodeshift,
+  MemberExpression,
+  ObjectProperty,
+  Property,
+} from "jscodeshift";
+
+import { getFunctionName } from "@codemod.com/codemod-utils/dist/jscodeshift/function.js";
+import { getFunctionComponents } from "@codemod.com/codemod-utils/dist/jscodeshift/react.js";
+
+const getComponentStaticPropValue = (
+  j: JSCodeshift,
+  root: Collection<any>,
+  componentName: string,
+  name: string,
+): ASTPath<MemberExpression> | null => {
+  return (
+    root
+      .find(j.MemberExpression, {
+        object: {
+          type: "Identifier",
+          name: componentName,
+        },
+        property: {
+          type: "Identifier",
+          name,
+        },
+      })
+      .paths()
+      .at(0) ?? null
+  );
+};
+
+const buildPropertyWithDefaultValue = (
+  j: JSCodeshift,
+  property: ObjectProperty | Property,
+  defaultValue: any,
+) => {
+  // Special handling for nested destructuring patterns
+  if (property.value.type === "ObjectPattern") {
+    return j.assignmentPattern(property.value, defaultValue);
+  }
+
+  if (!j.Identifier.check(property.key)) {
+    return property.value;
+  }
+
+  const identifier = j.identifier(property.key.name);
+  return j.assignmentPattern(identifier, defaultValue);
+};
+
+export default function transform(
+  file: FileInfo,
+  api: API,
+): string | undefined {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let isDirty = false;
+
+  getFunctionComponents(j, root).forEach((path) => {
+    const componentName = getFunctionName(j, path);
+
+    if (componentName === null) {
+      return;
+    }
+
+    const defaultProps = getComponentStaticPropValue(
+      j,
+      root,
+      componentName,
+      "defaultProps",
+    );
+
+    const defaultPropsRight = defaultProps?.parent?.value?.right ?? null;
+
+    if (!defaultProps || !j.ObjectExpression.check(defaultPropsRight)) {
+      return;
+    }
+
+    const defaultPropsMap = new Map();
+
+    defaultPropsRight.properties?.forEach((property) => {
+      if (
+        (j.Property.check(property) || j.ObjectProperty.check(property)) &&
+        j.Identifier.check(property.key)
+      ) {
+        defaultPropsMap.set(property.key.name, property.value);
+      }
+    });
+
+    const propsArg = path.value.params.at(0);
+
+    if (j.ObjectPattern.check(propsArg)) {
+      propsArg.properties.forEach((property) => {
+        if (
+          (j.Property.check(property) || j.ObjectProperty.check(property)) &&
+          j.Identifier.check(property.key)
+        ) {
+          if (defaultPropsMap.has(property.key.name)) {
+            isDirty = true;
+            property.value = buildPropertyWithDefaultValue(
+              j,
+              property,
+              defaultPropsMap.get(property.key.name),
+            );
+          }
+        }
+      });
+    }
+
+    j(defaultProps).closest(j.ExpressionStatement).remove();
+    isDirty = true;
+  });
+
+  return isDirty ? root.toSource() : undefined;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
     "compilerOptions": {
       "moduleDetection": "force", 
-      "target": "ES2015"
+      "allowSyntheticDefaultImports": true,
+      "esModuleInterop": true,
+      "types": ["vitest/globals"]
     }
   }  

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/transforms/__tests__/vitest/*.test.ts"],
+    globals: true,
+  },
+});


### PR DESCRIPTION
#### 📚 Description  

This PR is created to update the react-codemod repository with the updates for the react/19/replace-default-props codemod and to align the open-source content of this codemod in react-codemod similar to the [Codemod repository.](https://github.com/codemod-com/commons)

1. **Added Codemod Utils Package and Vitest Test Step**  
   - Added `@codemod.com/codemod-utils` package as a dependency to facilitate codemod development.  
   - Integrated the `vitest` test step for improved test coverage for transforms used `vitest` for test step.  

2. **Improved TypeScript Support**  
   - Fixed issues with missing `vitest/globals` types by adding type support.  
   - Updated TypeScript configuration to accommodate new transforms using typescript.  

3. **Added Vitest Configuration File**  
   - Introduced a dedicated `vitest.config.ts` file to centralize and streamline test configuration.  

4. **New Transform: React 19 Replace Default Props**  
   - Added a new transform `react-19-replace-default-props` to handle default props migration for React 19.  
   - Comprehensive tests were included to ensure reliability and coverage.  
   - Available will using `npx codemod react/19/replace-default-props`


#### 🧪 Test Plan  

The following steps were taken to ensure the changes function as intended:  
1. Ran the test suite with `vitest` to validate existing functionality and new transforms.  
2. Verified type resolution for `vitest/globals` and TypeScript transform compatibility.  
3. To confirm accuracy, the `react-19-replace-default-props` transform was executed against test cases.  
