### PR TITLE
feat: add remove legacy context transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "jscodeshift": "jscodeshift"
   },
   "dependencies": {
+    "@codemod.com/codemod-utils": "^1.0.0",
+    "@types/jscodeshift": "^0.12.0",
     "chalk": "^2.4.2",
     "eslint": "^6.6.0",
     "execa": "^3.2.0",
@@ -22,7 +24,10 @@
   },
   "jest": {
     "globals": {
-      "baseDir": "../"
+      "baseDir": "../",
+      "ts-jest": {
+        "tsconfig": "./tsconfig.codemod.json"
+      }
     },
     "testEnvironment": "node",
     "roots": [
@@ -32,13 +37,20 @@
     "transform": {
       "^.+\\.jsx?$": "babel-jest",
       "^.+\\.tsx?$": "ts-jest"
-    }
+    },
+    "transformIgnorePatterns": [
+      "/node_modules/(?!@codemod\\.com/codemod-utils)/.+\\.js$"
+    ],
+    "moduleFileExtensions": ["js", "ts", "tsx", "jsx"],
+    "extensionsToTreatAsEsm": [".ts", ".tsx", ".js", ".jsx"]
   },
   "devDependencies": {
     "@babel/core": "^7.6.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
     "@babel/preset-env": "^7.6.3",
+    "@jest/globals": "^29.7.0",
     "@types/jest": "^24.9.0",
+    "@types/node": "^22.12.0",
     "@typescript-eslint/parser": "^7.8.0",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",

--- a/transforms/__testfixtures__/remove-legacy-context/class-component.input.tsx
+++ b/transforms/__testfixtures__/remove-legacy-context/class-component.input.tsx
@@ -1,0 +1,16 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+class Parent extends React.Component {
+  static childContextTypes = {
+    foo: PropTypes.string.isRequired,
+  };
+
+  getChildContext() {
+    return { foo: "bar" };
+  }
+
+  render() {
+    return <Child />;
+  }
+}

--- a/transforms/__testfixtures__/remove-legacy-context/class-component.output.tsx
+++ b/transforms/__testfixtures__/remove-legacy-context/class-component.output.tsx
@@ -1,0 +1,10 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+const Context = React.createContext();
+
+class Parent extends React.Component {
+  render() {
+    return <Context value={{ foo: "bar" }}><Child /></Context>;
+  }
+}

--- a/transforms/__tests__/remove-legacy-context.codemod.test.ts
+++ b/transforms/__tests__/remove-legacy-context.codemod.test.ts
@@ -1,0 +1,55 @@
+import * as assert from "assert";
+import { readFile } from "fs/promises";
+import { join } from "path";
+import * as jscodeshift from "jscodeshift";
+import { type API } from "jscodeshift";
+import transform from "../remove-legacy-context.codemod";
+
+const buildApi = (parser: string | undefined): API => ({
+  j: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  jscodeshift: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  stats: () => {
+    console.error(
+      "The stats function was called, which is not supported on purpose"
+    );
+  },
+  report: () => {
+    console.error(
+      "The report function was called, which is not supported on purpose"
+    );
+  },
+});
+
+describe("remove-legacy-context", () => {
+  it("should remove getChildContext and childContextTypes from parent component", async () => {
+    const INPUT = await readFile(
+      join(
+        __dirname,
+        "..",
+        "__testfixtures__/remove-legacy-context/class-component.input.tsx"
+      ),
+      "utf-8"
+    );
+    const OUTPUT = await readFile(
+      join(
+        __dirname,
+        "..",
+        "__testfixtures__/remove-legacy-context/class-component.output.tsx"
+      ),
+      "utf-8"
+    );
+
+    const actualOutput = transform(
+      {
+        path: "index.js",
+        source: INPUT,
+      },
+      buildApi("tsx")
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ""),
+      OUTPUT.replace(/W/gm, "")
+    );
+  });
+});

--- a/transforms/remove-legacy-context.codemod.ts
+++ b/transforms/remove-legacy-context.codemod.ts
@@ -1,0 +1,79 @@
+// BUILT WITH https://codemod.studio
+
+import type { API, FileInfo, JSCodeshift } from "jscodeshift";
+import { findPatterns } from "./utils/analyze.codemod";
+
+import { getClassMethod } from "@codemod.com/codemod-utils";
+//  const FooContext = React.createContext();
+const buildContextVariableDeclaration = (j: JSCodeshift) =>
+  j.variableDeclaration("const", [
+    j.variableDeclarator(
+      j.identifier("Context"),
+      j.callExpression(
+        j.memberExpression(
+          j.identifier("React"),
+          j.identifier("createContext")
+        ),
+        []
+      )
+    ),
+  ]);
+
+const buildContextProvider = (j: JSCodeshift, value: any, renderedJsx: any) =>
+  j.jsxElement(
+    j.jsxOpeningElement(j.jsxIdentifier("Context"), [
+      j.jsxAttribute(j.jsxIdentifier("value"), j.jsxExpressionContainer(value)),
+    ]),
+    j.jsxClosingElement(j.jsxIdentifier("Context")),
+    [renderedJsx]
+  );
+
+export default function transform(
+  file: FileInfo,
+  api: API
+): string | undefined {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  let isDirty = false;
+
+  findPatterns(j, root)?.forEach((pattern) => {
+    if (!pattern) {
+      return;
+    }
+    isDirty = true;
+
+    const { classComponent, getChildContext, childContextTypes } = pattern;
+
+    const childContextValue =
+      j(getChildContext).find(j.ReturnStatement).paths().at(0)?.value
+        .argument ?? null;
+
+    j(childContextTypes).remove();
+    j(getChildContext).remove();
+
+    // add Context variable declaration
+    const variableDeclaration = buildContextVariableDeclaration(j);
+    classComponent.insertBefore(variableDeclaration);
+
+    const render = getClassMethod(j, classComponent, "render");
+
+    const renderReturnStatement = render
+      ? j(render).find(j.ReturnStatement).paths().at(0)
+      : null;
+
+    const renderedJsx = renderReturnStatement?.value.argument;
+
+    if (!renderedJsx) {
+      return;
+    }
+
+    renderReturnStatement.value.argument = buildContextProvider(
+      j,
+      childContextValue,
+      renderedJsx
+    );
+  });
+
+  return isDirty ? root.toSource() : undefined;
+}

--- a/transforms/utils/analyze.codemod.ts
+++ b/transforms/utils/analyze.codemod.ts
@@ -1,0 +1,26 @@
+import type { Collection, JSCodeshift } from "jscodeshift";
+
+import {
+  getClassComponents,
+  getClassMethod,
+  getClassProperty,
+} from "@codemod.com/codemod-utils";
+
+export const findPatterns = (j: JSCodeshift, root: Collection) =>
+  getClassComponents(j, root)
+    ?.paths()
+    .map((path) => {
+      const childContextTypes = getClassProperty(j, path, "childContextTypes");
+      const getChildContext = getClassMethod(j, path, "getChildContext");
+
+      if (!childContextTypes || !getChildContext) {
+        return;
+      }
+
+      return {
+        classComponent: path,
+        childContextTypes,
+        getChildContext,
+      };
+    })
+    .filter(Boolean);

--- a/tsconfig.codemod.json
+++ b/tsconfig.codemod.json
@@ -1,0 +1,40 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "moduleResolution": "node",
+    "module": "NodeNext",
+    "target": "ES2015",
+    "lib": ["ESNext", "DOM"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "useDefineForClassFields": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "incremental": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "allowJs": true,
+    "outDir": "./dist",
+    "rootDir": "./transforms",
+    "moduleDetection": "auto"
+  },
+  "include": [
+    "./transforms/**/*.codemod.ts",
+    "./transforms/**/*.codemod.js",
+    "./transforms/**/*.codemod.tsx",
+    "./transforms/**/*.codemod.jsx"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
 {
-    "compilerOptions": {
-      "moduleDetection": "force", 
-      "target": "ES2015"
-    }
-  }  
+  "compilerOptions": {
+    "moduleDetection": "force", 
+    "target": "ES2015"
+  },
+  "references": [
+    { "path": "./tsconfig.codemod.json" }
+  ]
+}  


### PR DESCRIPTION
#### 📚 Description  

This PR introduces the new `remove-legacy-context` transform.  

1. **New Transform: Prop Types to TypeScript**  
   - Added `remove-legacy-context` transform to assist in migrating from `prop-types` to TypeScript interfaces.  
   - Ensured compatibility with common patterns in React components.  
   - Available via `npx codemod react/19/remove-legacy-context`.  

#### 🧪 Test Plan  

Validate the new transform tests using `jest`.